### PR TITLE
Adds a link to edit the current page in GitHub

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,5 +3,6 @@
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
 
     <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.</p>
+    <p><a href="{{ site.repos[0].url }}/edit/18f-pages/{{ page.path }}">Edit this page on GitHub</a></p>
   </div><!--/.wrap -->
 </footer>


### PR DESCRIPTION
Assumes that guides will have a full url to the GitHub repo in the _config.yml and that all guides only have only one repo in the "repos" field of that file. This may be incorrect, see, for example,
[accessibility](https://github.com/18F/accessibility/blob/18f-pages/_config.yml#L71-L74).
