### PR TITLE
Removing the default margin on body

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -39,6 +39,7 @@ body {
     font-weight: 400;
     font-style: normal;
     line-height: 1.466666667;
+    margin: 0;
 }
 
 h1,


### PR DESCRIPTION
Super minor nag, but right now there's a gap around the entire page page, so this patch closes it.

Before:
![screen shot 2015-07-06 at 9 53 21 am](https://cloud.githubusercontent.com/assets/1696495/8528040/4095fd84-23c5-11e5-8e9d-b490a783c848.png)

After
![screen shot 2015-07-06 at 9 53 42 am](https://cloud.githubusercontent.com/assets/1696495/8528039/40771248-23c5-11e5-856a-b770c1413331.png)
