### PR TITLE
Fixing the nested child pages

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
 <script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/accordion.js"></script>
 {% if page.title == "Keyboard Access" %}
 <script type="text/javascript">
 	$(document).ready(function(){

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,40 +5,22 @@
     <ul>
       {% for link in site.navigation %}
         {% if link.internal == true %}
-          <li class="group {% if page.title == link.text %}sidebar-nav-active{% else if page.parent == link.text %}sidebar-parent-active{% endif %}">
-            <a href="{{ site.baseurl }}/{{ link.url }}"  {% if page.title == link.text %}title='Selected'{% endif %}>{{ link.text }}</a>
+          <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
+            <a href="{{ site.baseurl }}/{{ link.url }}"  {% if page.title == link.text %}title='Current Page'{% endif %}>{{ link.text }}</a>
             {% if link.children %}
-            <label class="visuallyhidden" for="expand-{{ forloop.index }}">View more</label>
-            <input class="expand-subnav" 
-                    type="checkbox" 
-                    id="expand-{{ forloop.index  }}"
-                    {% if page.title == link.text or page.parent == link.text %}checked{% endif %}>
-              <ul class="nav-children">
+              <button class="expand-subnav"
+                      aria-expanded="{% if link.text == page.parent or link.text == page.title %}true{% else %}false{% endif %}"
+                      aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
+              <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}" 
+                  aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
                 {% for child in link.children %}
-                  <li {% if page.title == child.text %}class="sidebar-nav-active"{% endif %}>
-                    <a href="{{ site.baseurl }}/{{ link.url}}{{ child.url }}"  {% if page.title == child.text %}title='Selected'{% endif %}>{{ child.text }}</a>
+                  <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
+                    <a href="{{ site.baseurl }}/{{ link.url}}{{ child.url }}"  
+                      title="{% if page.title == child.text %}Current Page{% endif %}">{{ child.text }}</a>
                   </li>
                 {% endfor %}
               </ul>
             {% endif %}
-          </li>
-        {% else %}
-          <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
-            <a href="{{ link.url }}" {% if page.title == link.text %}title='Selected'{% endif %}>{{ link.text }}</a>
-            {% if link.children %}
-            <label class="visuallyhidden" for="expand-{{ forloop.index }}">View more</label>
-            <input class="expand-subnav" 
-                    type="checkbox" 
-                    id="expand-{{ forloop.index  }}"
-                    {% if page.title == link.text or page.parent == link.text %}checked{% endif %}>
-              <ul class="nav-children">
-                {% for child in link.children %}
-                  <li {% if page.title == child.text %}class="sidebar-nav-active"{% endif %}>
-                    <a href="{{ site.baseurl }}/{{ link.url}}{{ child.url }}"  {% if page.title == child.text %}title='Selected'{% endif %}>{{ child.text }}</a>
-                  </li>
-                {% endfor %}
-              </ul>
-            {% endif %}         
           </li>
         {% endif %}
       {% endfor %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,25 +4,26 @@
   <nav class="sidebar-nav" role="navigation">
     <ul>
       {% for link in site.navigation %}
-        {% if link.internal == true %}
-          <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
-            <a href="{{ site.baseurl }}/{{ link.url }}"  {% if page.title == link.text %}title='Current Page'{% endif %}>{{ link.text }}</a>
-            {% if link.children %}
-              <button class="expand-subnav"
-                      aria-expanded="{% if link.text == page.parent or link.text == page.title %}true{% else %}false{% endif %}"
-                      aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
-              <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}" 
-                  aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
-                {% for child in link.children %}
-                  <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
-                    <a href="{{ site.baseurl }}/{{ link.url}}{{ child.url }}"  
-                      title="{% if page.title == child.text %}Current Page{% endif %}">{{ child.text }}</a>
-                  </li>
-                {% endfor %}
-              </ul>
-            {% endif %}
-          </li>
-        {% endif %}
+        <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
+          <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
+            title="{% if page.title == link.text %}Current Page
+                  {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
+          {% if link.children %}
+            <button class="expand-subnav"
+                    aria-expanded="{% if link.text == page.parent or link.text == page.title %}true{% else %}false{% endif %}"
+                    aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
+            <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}" 
+                aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
+              {% for child in link.children %}
+                <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
+                  <a href="{% if link.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"  
+                    title="{% if page.title == child.text %}Current Page
+                          {% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </li>
       {% endfor %}
     </ul>
   </nav>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -255,7 +255,7 @@ Navigation
     font-size: 20px;
     height: 30px;
     line-height: 1;
-    margin: 12px;
+    margin: 8px;
     padding-bottom: 5px;
     position: relative;
     width: 30px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -247,55 +247,48 @@ Navigation
 .expand-subnav {
     background: none;
     border: none;
-    border-radius: 24px;
+    border-radius: 30px;
     color: #0072ce;
     cursor: pointer;
     display: block;
     float: right;
-    height: 24px;
+    font-size: 20px;
+    height: 30px;
+    line-height: 1;
     margin: 12px;
+    padding-bottom: 5px;
     position: relative;
-    width: 24px;
+    width: 30px;
     -webkit-appearance: none;
     -moz-appearance: none;
     -o-appearance: none;
     appearance: none;    
+    -webkit-transition: -webkit-transform .2s;
+    -moz-transition: -moz-transform .2s;
+    -o-transition: -o-transform .2s;
+    transition: transform .2s;
 }
 
-.expand-subnav:before {
-    content: "+";
-    display: block;
-    font-size: 20px;
-    left: 6px;
-    line-height: 1;
-    position: absolute;
-    top: 0px;
-    -webkit-transition: transform .2s, left .2s;
-    -moz-transition: transform .2s, left .2s;
-    -o-transition: transform .2s, left .2s;
-    transition: transform .2s, left .2s;    
-}
-
+.expand-subnav:hover,
 .expand-subnav:focus {
-    background: #0072ce;
+    background-color: #0072ce;
     color: #fff;
     outline: none;
 }
 
-.expand-subnav:checked:before {
-    left: 7px;
-    -webkit-tranform: rotate3d(0, 0, 1, 45deg);
-    -moz-transform: rotate3d(0, 0, 1, 45deg);
-    -o-transform: rotate3d(0, 0, 1, 45deg);
-    transform: rotate3d(0, 0, 1, 45deg);
-    -webkit-transition: transform .2s, left .2s;
-    -moz-transition: transform .2s, left .2s;
-    -o-transition: transform .2s, left .2s;
-    transition: transform .2s, left .2s;
+.expand-subnav[aria-expanded=true] {
+    -webkit-transform: rotate(45deg);
+    -moz-transform: rotate(45deg);
+    -o-transform: rotate(45deg);
+    transform: rotate(45deg);
 }
 
-/* Show the menu when the checkbox is checked */
-.expand-subnav:checked + .nav-children {
+
+.nav-children[aria-hidden=true] {
+    max-height: 0;
+}
+
+.nav-children {
     display: block;
     max-height: 400px;
     opacity: 1;

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -6,10 +6,9 @@
 function Accordion($el) {
   var self = this;
   this.$root = $el;
-  this.expanded = $el.find('[aria-hidden=false]').attr('id');
   this.$root.on('click', 'button', function(ev) {
     ev.preventDefault();
-    if ( $(this).attr('aria-controls') === self.expanded ) {
+    if ( $(this).attr('aria-expanded') === 'true' ) {
       self.hide($(this));
     } else {
       self.show($(this));
@@ -25,7 +24,6 @@ Accordion.prototype.$ = function(selector) {
 Accordion.prototype.hide = function($button) {
   var selector = $button.attr('aria-controls'),
       $content = this.$('#' + selector);
-  this.expanded = '';
   $button.attr('aria-expanded', false);
   $content.attr('aria-hidden', true);
 };
@@ -33,8 +31,6 @@ Accordion.prototype.hide = function($button) {
 Accordion.prototype.show = function($button) {
   var selector = $button.attr('aria-controls'),
       $content = this.$('#' + selector);
-
-  this.expanded = selector;
   $button.attr('aria-expanded', true);
   $content.attr('aria-hidden', false);
 };

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,0 +1,57 @@
+/*  Originally from the Government Wide Pattern Library.
+    Modified to check for items expanded on page load and
+    to allow you to close an accordion without opening another
+*/
+
+function Accordion($el) {
+  var self = this;
+  this.$root = $el;
+  this.expanded = $el.find('[aria-hidden=false]').attr('id');
+  this.$root.on('click', 'button', function(ev) {
+    ev.preventDefault();
+    if ( $(this).attr('aria-controls') === self.expanded ) {
+      self.hide($(this));
+    } else {
+      self.show($(this));
+    }
+  });
+
+}
+
+Accordion.prototype.$ = function(selector) {
+  return this.$root.find(selector);
+}
+
+Accordion.prototype.hide = function($button) {
+  var selector = $button.attr('aria-controls'),
+      $content = this.$('#' + selector);
+  this.expanded = '';
+  $button.attr('aria-expanded', false);
+  $content.attr('aria-hidden', true);
+};
+
+Accordion.prototype.show = function($button) {
+  var selector = $button.attr('aria-controls'),
+      $content = this.$('#' + selector);
+
+  this.expanded = selector;
+  $button.attr('aria-expanded', true);
+  $content.attr('aria-hidden', false);
+};
+
+Accordion.prototype.hideAll = function() {
+  var self = this;
+  this.$('button').each(function() {
+    self.hide($(this));
+  });
+};
+
+function accordion($el) {
+  return new Accordion($el);
+}
+
+$(function() {
+  $('.sidebar-nav').each(function() {
+    accordion($(this));
+  });
+});


### PR DESCRIPTION
The previous nested page menu toggle didn't work in firefox and also lacked the proper aria attributes. This approach uses the gov-wide-pattern-library accordion as the basis and then modifies it slightly so that you can open and close one item at a time (or have multiple items open) and also checks to see if any items are open on page load (such as when on a parent or child page).
