### PR TITLE
Add _scripts/create-new-repo; explain script usage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@ markdown: redcarpet
 name: 18F Guides Template
 exclude:
 - go
-- copy-template
 - Gemfile
 - Gemfile.lock
 - README.md
@@ -27,11 +26,11 @@ navigation:
 - text: Introduction
   url: index.html
   internal: true
-- text: Adding a New Page
+- text: Adding a new page
   url: adding-a-new-page/
   internal: true
   children:
-  - text: Making a Child Page
+  - text: Making a child page
     url: making-a-child-page/
     internal: true
 - text: Adding images

--- a/_scripts/copy-template
+++ b/_scripts/copy-template
@@ -17,10 +17,12 @@ fi
 
 # Hack per:
 # http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
-pushd $(dirname $0) >/dev/null
+pushd $(dirname $(dirname $0)) >/dev/null
 TEMPLATE_ROOT=$(pwd -P)
 popd >/dev/null
 
 PATH=/usr/bin
 TARGET=$(echo "$1/" | sed 's#//$#/#')
-rsync -av --exclude .DS_Store $TEMPLATE_ROOT/{_includes,_layouts,assets} $TARGET
+rsync -av --exclude .DS_Store\
+  $TEMPLATE_ROOT/{_includes,_layouts,_scripts,assets}\
+  $TARGET

--- a/_scripts/create-new-repo
+++ b/_scripts/create-new-repo
@@ -1,0 +1,40 @@
+#! /bin/bash
+#
+# Clears out Guides Template files and repo for a new Guide.
+#
+# Author: Mike Bland <michael.bland@gsa.gov>
+
+# Hack per:
+# http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+pushd $(dirname $(dirname $0)) >/dev/null
+PROJECT_ROOT=$(pwd -P)
+popd >/dev/null
+
+TEMPLATE_FILES="\
+  pages/child-page.md \
+  pages/config.md \
+  pages/github.md \
+  pages/images.md \
+  pages/new-page.md \
+  pages/posting.md \
+  images/18f-pages.png \
+  images/description.png \
+  images/gh-add-guide.png \
+  images/gh-branches-link.png \
+  images/gh-default-branch.png \
+  images/gh-settings-button.png \
+  images/gh-webhook.png \
+  images/images.png"
+
+set -e
+pushd $PROJECT_ROOT >/dev/null
+echo "Clearing Guides Template files"
+rm $TEMPLATE_FILES
+echo "Removing old git repository"
+rm -rf .git
+echo "Creating a new git repository"
+git init
+echo "Adding files for initial commit"
+git add .
+popd >/dev/null
+echo "All done! Run 'git commit' to create your first commit."

--- a/pages/.gemrc
+++ b/pages/.gemrc
@@ -1,2 +1,0 @@
-install: --no-ri --no-rdoc
-update:  --no-ri --no-rdoc

--- a/pages/child-page.md
+++ b/pages/child-page.md
@@ -1,8 +1,8 @@
 ---
 permalink: /adding-a-new-page/making-a-child-page/
 layout: default
-title: Making a Child Page
-parent: Adding a New Page
+title: Making a child page
+parent: Adding a new page
 ---
 
 If you want to nest a page under a parent page, follow the instructions to [add a new page](/adding-a-new-page/) with two additions to the YAML front matter. Here is the front-matter for this page:
@@ -25,11 +25,11 @@ navigation:
 - text: Introduction
   url: index.html
   internal: true
-- text: Adding a New Page
+- text: Adding a new page
   url: adding-a-new-page/
   internal: true
   children:
-    - text: Making a Child Page
+    - text: Making a child page
       url: making-a-child-page/
       internal: true
 ```

--- a/pages/config.md
+++ b/pages/config.md
@@ -44,20 +44,30 @@ directory:
 
 ```yaml
 exclude:
-{% for i in site.exclude %}{% if i != 'copy-template' %}- {{ i }}
-{% endif %}{% endfor %}```
+{% for i in site.exclude %}- {{ i }}
+{% endfor %}```
 
 ## <a name="register-new-pages"></a>Register new pages
 
 The `navigation:` list is used to generate the table of contents. Add a new
-entry for any new page added. For example, the `navigation:` section of this
-guide contains:
+entry for any new page added.
+
+You can run `_scripts/update-config.rb` to do this automatically (and run it
+again whenever you add pages or make `title:`, `permalink:`, or `parent:`
+changes), but you may want to edit the results by hand to produce the desired
+ordering of pages.
+
+For example, the `navigation:` section of this guide contains:
 
 ```yaml
 navigation:
 {% for i in site.navigation %}- text: {{ i.text }}
   url: {{ i.url }}
-  internal: {{ i.internal }}
+  internal: {{ i.internal }}{% if i.children %}
+  children:{% for child in i.children %}
+  - text: {{ child.text }}
+    url: {{ child.url }}
+    internal: {{ child.internal }}{% endfor %}{% endif %}
 {% endfor %}```
 
 ## <a name="update-repository-list"></a>Update the repository list

--- a/pages/github.md
+++ b/pages/github.md
@@ -13,24 +13,23 @@ publish your guide.
 ## <a name="create-local-repo"></a>Create a new local repository
 
 Once you've got the `_config.yml` file up-to-date, in the root directory of
-your guide's repository, copy and paste these commands to remove all of the
-pages and images that came with this template (be careful not to remove any files
-that you actually intend to keep):
+your guide's repository, run `_scripts/create-new-repo` to remove all of the
+pages and images that came with this template (make sure you didn't reuse one
+of the file names from this template!) and create a new Git repository:
 
 ```
-$ rm copy-template {% for p in site.pages %}{% if p.path contains 'pages/' %}{{ p.path }} {% endif %}{% endfor %}
-$ rm {% for f in site.static_files %}{% if f.path contains '/images/' %}{{ f.path | replace_first:'/','' }} {% endif %}{% endfor %}
+$ _scripts/create-new-repo
+
+Clearing Guides Template files
+Removing old git repository
+Creating a new git repository
+Initialized empty Git repository in .../.git/
+Adding files for initial commit
+All done! Run 'git commit' to create your first commit.
 ```
 
-Then execute the following to detach from the the original template repository
-and create a new one for your guide:
-
-```
-$ rm -rf .git
-$ git init
-$ git add .
-$ git commit -m 'Initial commit'
-```
+Then execute `git commit -m 'Initial commit'` to create your new Guide!
+(Unless you're Git savvy and would like to tweak things a bit first.)
 
 ## <a name="create-18f-repo"></a>Create a new 18F GitHub repository
 

--- a/pages/new-page.md
+++ b/pages/new-page.md
@@ -1,7 +1,7 @@
 ---
 permalink: /adding-a-new-page/
 layout: default
-title: Adding a New Page
+title: Adding a new page
 ---
 To add new pages to the guide, first create a new
 [Markdown](http://daringfireball.net/projects/markdown/syntax) file in the


### PR DESCRIPTION
Also made updates to titles, ran _scripts/update-config.rb to apply the changes to _config.yml, and updated the code used to generate the _config.yml example in the "Updating the config file" chapter.

`_scripts/create-new-repo` seemed like a better idea than the existing instructions. Tested it in a fresh clone of 18F/guides-template to make sure it worked as advertised.

cc: @melodykramer @emileighoutlaw @awfrancisco @noahmanger 
