### PR TITLE
Include CFPB DOCter attribution in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,8 @@
   <div class="wrap">
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
 
-    <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.</p>
+    <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.
+    The <a href="https://github.com/18F/guides-template/">18F Guides theme</a> is based on <a href="https://github.com/cfpb/docter/">DOCter</a> from <a href="http://cfpb.github.io/">CFPB</a>.</p>
     <p><a href="{{ site.repos[0].url }}/edit/18f-pages/{{ page.path }}">Edit this page on GitHub</a></p>
   </div><!--/.wrap -->
 </footer>


### PR DESCRIPTION
See 18F/open-source-guide#6. Once added to this template, we can import the update (along with other recent template updates) into the existing guides via the template's _scripts/copy-template (explained in [the _Updating an existing guide_ section of the Guides Template intro](https://pages.18f.gov/guides-template/)).

cc: @jpyuda @noahmanger 
