### PR TITLE
Fix sidebar link styling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,3 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   rouge
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,3 +70,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   rouge
+
+BUNDLED WITH
+   1.10.6

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -203,7 +203,6 @@ Navigation
   list-style: none;
   border-bottom: 1px solid #babbbd;
   font-size: 1.125em;
-  padding-left: 4px;
   overflow: hidden;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -171,7 +171,10 @@ Navigation
 
 .sidebar-nav a {
   display: block;
-  padding: 10px;
+  padding-bottom: 10px;
+  padding-right: 10px;
+  padding-left: 14px;
+  padding-top: 10px;
   -webkit-transition: .4s;
   transition: .4s;
   width: 80%;


### PR DESCRIPTION
Before there was an extra bit of border sticking out on the link hover. I removed the padding form the list and moved it to the link itself.

This is what it looks like now:
<img width="347" alt="screen shot 2015-08-10 at 9 48 58 pm" src="https://cloud.githubusercontent.com/assets/5249443/9190371/588848f2-3fa9-11e5-8a54-5b4c9c215a10.png">

This is what it looked like before:
<img width="191" alt="screen shot 2015-08-10 at 9 39 29 pm" src="https://cloud.githubusercontent.com/assets/5249443/9190364/37d48ab2-3fa9-11e5-9ca8-6f0dc1c041c2.png">
