### PR TITLE
Update font weights

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/images/favicons/18f-center-114.png">
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/images/favicons/18f-center-144.png">
   <link rel="icon" type="image/png" sizes="192x192" href="{{ site.baseurl }}/images/favicons/18f-center-192.png" />
-  <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:300,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,600' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/images/favicons/18f-center-114.png">
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/images/favicons/18f-center-144.png">
   <link rel="icon" type="image/png" sizes="192x192" href="{{ site.baseurl }}/images/favicons/18f-center-192.png" />
-  <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,400italic,600' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css">


### PR DESCRIPTION
This updates font weights from light (300) to normal (400). This also adds in true italics so the browser doesn't have to simulate it.

This addresses #29.

This is what it looks like:
<img width="1141" alt="screen shot 2015-08-11 at 7 29 16 am" src="https://cloud.githubusercontent.com/assets/5249443/9199986/6da5d83e-3ffa-11e5-9093-6b79624eeaeb.png">
