### PR TITLE
Remove Raleway 400 font weight

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/images/favicons/18f-center-114.png">
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/images/favicons/18f-center-144.png">
   <link rel="icon" type="image/png" sizes="192x192" href="{{ site.baseurl }}/images/favicons/18f-center-192.png" />
-  <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,400italic,600' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Raleway:700%7COpen+Sans:400,400italic,600' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/custom.css">


### PR DESCRIPTION
This removes Raleway 400 from our font family bc it's not used anywhere on the 18F Guides website.
