### PR TITLE
Update gems after ruby 2.2.3 upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     blankslate (2.1.2.4)
-    celluloid (0.16.1)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     classifier-reborn (2.0.3)
       fast-stemmer (~> 1.0)
@@ -36,7 +36,7 @@ GEM
       toml (~> 0.1.0)
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
-    jekyll-gist (1.3.1)
+    jekyll-gist (1.3.2)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)


### PR DESCRIPTION
I've upgraded the global ruby version on pages.18f.gov to 2.2.3 (and am in the process of upgrading it on 18f.gsa.gov), and as it turns out, [celluloid-0.16.1 has been yanked](https://rubygems.org/gems/celluloid/versions/0.16.1). I may need to go around and update other guides as well.

As for the Ruby upgrade, [2.2.3 contains a security fix for a DNS hijacking vulnerability in RubyGems](https://www.ruby-lang.org/en/news/2015/08/18/ruby-2-2-3-released/).

cc: @afeld @gboone @konklone @NoahKunin 
