### PR TITLE
Use 18F Pages-generated baseurl, asset_root config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,3 @@
-baseurl: /guides-template
-
-# To use the shared 18F Guides styles when deploying to pages.18f.gov,
-# uncomment the following:
-#asset_root: /guides-template
-
 markdown: redcarpet
 name: 18F Guides Template
 exclude:


### PR DESCRIPTION
This will determine for sure whether 18F/pages#24 works as advertised.

@konklone and @juliaelman, if this works, you should be free to host an instance of Pulse on https://pages-staging.18f.gov/pulse, after converting links from `href="/"` to `href="{{ site.baseurl }}/"`. I could might even put a PR together for you via `find | xargs sed`.

cc: @arowla @afeld @msecret
