### PR TITLE
Fix `./go update_theme` command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     go_script (0.1.3)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.1.0)
+    guides_style_18f (0.1.1)
       jekyll (~> 2.5)
       rouge (~> 1.9)
       sass (~> 3.4)

--- a/go
+++ b/go
@@ -40,7 +40,7 @@ def_command :update_nav, 'Update the \'navigation:\' data in _config.yml' do
 end
 
 def_command :update_theme, 'Update the guides_style_18f gem' do
-  exec_cmd 'bundle update --source guides_style_18f'
+  exec({ 'RUBYOPT' => nil }, 'bundle', *%w(update --source guides_style_18f))
 end
 
 def_command :update_gems, 'Update Ruby gems' do |gems|


### PR DESCRIPTION
Turns out the original command wasn't doing anything because the RUBYOPT environment variable (`-rbundler/setup`) was passed through to the `bundle update` command and preventing it from working properly.

cc: @arowla @melodykramer 
