### PR TITLE
Clear RUBYOPT before reexecuting

### DIFF
--- a/go
+++ b/go
@@ -6,7 +6,7 @@ Dir.chdir File.dirname(__FILE__)
 
 def try_command_and_restart(command)
   exit $CHILD_STATUS.exitstatus unless system command
-  exec RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV)
+  exec({ 'RUBYOPT' => nil }, RbConfig.ruby, *[$PROGRAM_NAME].concat(ARGV))
 end
 
 begin


### PR DESCRIPTION
`require 'bundler/setup'` will set RUBYOPT to `-rbundler/setup`. Without this
update, when the Gemfile is updated, re-executing the script won't allow the
new process to see the updates, as bundler won't update the load path if
RUBYOPT is already set.

cc: @arowla @gboone 
