### PR TITLE
Document the 18F organization publishing webhook

### DIFF
--- a/pages/posting.md
+++ b/pages/posting.md
@@ -43,6 +43,15 @@ but isn't strictly necessary.
 
 ## <a name="set-webhook"></a>Create the publishing webhook
 
+**18F Team members can skip this step!** Our pages are now building via an
+organization-wide GitHub webhook. There is no need to set up a repo-specific
+webhook anymore.
+
+**Other users running their own [18F/pages](https://github.com/18F/pages/)
+instance:** You can either set up a webhook for your organization, or you can
+add it per-repository as described below. The steps are nearly identical in
+either case.
+
 Go into the **Webhooks & Services** section of the **Settings** section
 and click the **Add webhook** button. On the following screen, set the
 **Payload URL** to `https://pages.18f.gov/deploy`, leave the **Secret** field


### PR DESCRIPTION
The dream is real! 18F Pages no longer requires the webhook setup step; there's now one webhook for the 18F GitHub org that rules them all. https://pages.18f.gov/fedspendingtransparency.github.io/ has already been published using the org-wide webhook model. 

If the preference would be to excise this section entirely, I can do that; but I figure it's worth leaving in for folks outside 18F.

Now that 18F/pages#37 is deployed, it's safe to start gradually removing repo-specific publishing webhooks. I've cc'd a bunch of folks that I know help maintain Guides/Pages; feel free to remove your webhooks at your earliest convenience.

cc: @afeld @gboone @melodykramer @emileighoutlaw @kategarklavs @bsweger @elainekamlley @wslack @arowla @meiqimichelle @gbinal @awfrancisco @andrewmaier @jenniferthibault @msecret @awfrancisco @shawnbot
