### PR TITLE
Bump jekyll_pages_api_search v0.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     jekyll_pages_api (0.1.5)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.4.0)
+    jekyll_pages_api_search (0.4.1)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
     kramdown (1.9.0)


### PR DESCRIPTION
Includes a bugfix for the search result page permalink (18F/jekyll_pages_api_search#19).

cc: @andrewmaier @mtorres253 
