### PR TITLE
downgrade guides style gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'rouge'
 gem 'go_script'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f'
+  # temporary fix for https://github.com/18F/guides-template/pull/81#issuecomment-204175269
+  gem 'guides_style_18f', '0.4.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     go_script (0.1.9)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.4.4)
+    guides_style_18f (0.4.3)
       jekyll
       jekyll_pages_api
       jekyll_pages_api_search
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   go_script
-  guides_style_18f
+  guides_style_18f (= 0.4.3)
   jekyll
   redcarpet
   rouge


### PR DESCRIPTION
Upgrading caused a bug, because the path for the private-eye JS file changed, but the sites using an old version of the gem were still requesting the old URL. Should fix the issue of the private-eye being broken on existing sites.

/cc https://github.com/18F/pages-server/issues/55 https://github.com/18F/guides-template/pull/81#issuecomment-204175269

/cc @jbarnicle @wslack
