### PR TITLE
upgrade guides_style_18f to 0.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ gem 'rouge'
 gem 'go_script'
 
 group :jekyll_plugins do
-  # temporary fix for https://github.com/18F/guides-template/pull/81#issuecomment-204175269
-  gem 'guides_style_18f', '0.4.3'
+  gem 'guides_style_18f'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     go_script (0.1.9)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.4.3)
+    guides_style_18f (0.4.4)
       jekyll
       jekyll_pages_api
       jekyll_pages_api_search
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   go_script
-  guides_style_18f (= 0.4.3)
+  guides_style_18f
   jekyll
   redcarpet
   rouge


### PR DESCRIPTION
Contains https://github.com/18F/guides-style/pull/60, and should fix Private Eye on our Pages sites.
