### PR TITLE
Update 18F Guides URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a skeleton repo containing the
 [CFPB/DOCter](https://github.com/CFPB/DOCter)-based
 [Jekyll](http://jekyllrb.com/) template for
-[18F Guides](http://18f.github.io/guides/).
+[18F Guides](https://pages.18f.gov/guides/).
 
 ### Getting started
 


### PR DESCRIPTION
The URL for 18F Guides in the readme was incorrect
